### PR TITLE
Fix docstring typo in slope method

### DIFF
--- a/pyquations/algebra/slope.py
+++ b/pyquations/algebra/slope.py
@@ -24,10 +24,10 @@ def slope(x1: float, y1: float, x2: float, y2: float) -> float:
             line with an undefined slope.
 
     Examples:
-        >>> slope_formula(1, 2, 3, 6)
+        >>> slope(1, 2, 3, 6)
         2.0
 
-        >>> slope_formula(0, 0, 5, 5)
+        >>> slope(0, 0, 5, 5)
         1.0
 
     Resources:


### PR DESCRIPTION
# Checklist

- [ ] [added release note entry](https://pyquations.com/development_guide/release_notes.html#what-to-include) to the `docs/release_notes/vX.X.X.rst` file
- [ ] [imported new packages/modules](https://pyquations.com/development_guide/project_structure.html#organizing-imports) into `pyquations/__init__.py` and the `pyquations/{package}/__init__.py` file and included them in the `__all__` list
- [X] [locally built the documentation](https://pyquations.com/development_guide/documentation.html#building-the-documentation-locally) and verified that it renders correctly
- [X] followed all other requirements outlined in the [development guide](https://pyquations.com/development_guide/index.html)

